### PR TITLE
GtkDialog type-hint changed from normal to dialog

### DIFF
--- a/setup/ibus-libpinyin-preferences.ui
+++ b/setup/ibus-libpinyin-preferences.ui
@@ -163,7 +163,7 @@
     <property name="title" translatable="yes">Preferences</property>
     <property name="window-position">center-always</property>
     <property name="icon-name">gtk-preferences</property>
-    <property name="type-hint">normal</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>


### PR DESCRIPTION
The dialog window should be hinted as dialog so Window Managers such as Tiling WM is able to know the appropriate window state.